### PR TITLE
WIP: Started checkpoint file reporter

### DIFF
--- a/ipcfg/checkpointreporter.py
+++ b/ipcfg/checkpointreporter.py
@@ -1,0 +1,100 @@
+#-----------------------------------------------------------------------------
+# Imports
+#-----------------------------------------------------------------------------
+import os
+import shutil
+import json
+import xdrlib
+
+import simtk.openmm as mm
+
+#-----------------------------------------------------------------------------
+# Classes
+#-----------------------------------------------------------------------------
+
+
+class CheckpointReporter(object):
+    """Reporter to save checkpoint files. Checkpoint files are hardware and
+    platform specific -- they can only be reinstantiated on the same hardware
+    they were produced on. Because of that specificity, they are able to save
+    almost all of the data structures used, including things like the state
+    of the internal random number generators.
+    """
+    def __init__(self, path, reportInterval, backupPath=None):
+        self._report_interval = reportInterval
+        self._open = True
+        self._initialized = False
+        
+        self._path = path
+        if backupPath is None:
+            self._backup_path = '%s.bak' % path
+        else:
+            self._backup_path = backupPath
+        self._static_data_length = None
+
+    def _initialize(self, simulation):
+        """Delayed initalization -- done only once we have a handle to the
+        simulation"""
+        
+        platform = simulation.context.getPlatform()
+        # Get all of the platform properties. We are going to make sure these
+        # match when we instantiate the checkpoint file back up.
+        properties = {'OpenMMVersion': platform.getOpenMMVersion(),
+                      'PlatformName': platform.getName()}
+        for key in platform.getPropertyNames():
+            properties[key] = platform.getPropertyValue(simulation.context, key)
+
+        self._write_static_data(properties, simulation.context.getIntegrator(),
+                                simulation.context.getSystem())
+
+    def _write_static_data(self, platformProperties, integrator, system):
+        packer = xdrlib.Packer()
+        packer.pack_string(json.dumps(platformProperties))
+        packer.pack_string(mm.XmlSerializer.serialize(integrator))
+        packer.pack_string(mm.XmlSerializer.serialize(system))
+        
+        buf = packer.get_buffer()
+        with open(self._path, 'wb') as f:
+            f.write(buf)
+            self._static_data_length = f.tell()
+
+    def _create_checkpoint(self, context):
+         packer = xdrlib.Packer()
+         packer.pack_string(context.createCheckpoint())
+         return packer.get_buffer()
+
+    def describeNextReport(self, simulation):
+        """Get information about the next report this object will generate.
+
+        Parameters:
+         - simulation (Simulation) The Simulation to generate a report for
+        Returns: A five element tuple.  The first element is the number of steps until the
+        next report.  The remaining elements specify whether that report will require
+        positions, velocities, forces, and energies respectively.
+        """
+        steps = self._report_interval - simulation.currentStep % self._report_interval
+        return (steps, False, False, False, False)
+
+    def report(self, simulation, state=None):
+        """Generate a report.
+
+        Parameters:
+         - simulation (Simulation) The Simulation to generate a report for
+         - state (State) The current state of the simulation
+        """
+        if not self._initialized:
+            self._initialize(simulation)
+            self._initialized = True
+
+        check = self._create_checkpoint(simulation.context)
+        # copy the current checkpoint to the backup before writing
+        # the new backup
+        shutil.copy2(self._path, self._backup_path)
+
+        with open(self._path, 'r+b') as f:
+            f.seek(self._static_data_length)
+            f.write(check)
+
+
+    def __del__(self):
+        os.unlink(self._backup_path)

--- a/openmm
+++ b/openmm
@@ -16,6 +16,7 @@ from simtk import unit
 from simtk.openmm import app
 from simtk import openmm as mm
 from ipcfg.progressreporter import ProgressReporter
+from ipcfg.checkpointreporter import CheckpointReporter
 
 # command line configuration system
 from ipcfg.extratraitlets import Quantity
@@ -362,8 +363,8 @@ class Simulation(AppConfigurable):
     """Parameters for the simulation, including the mode and frequency
     with which files are saved to disk, the number of steps, etc."""
 
-    n_steps = CInt(1000, config=True,
-                  help='''Number of steps of simulation to run.''')
+    n_steps = CInt(1000, config=True, help='''Number of steps of simulation
+        to run.''')
     minimize = CBool(True, config=True, help='''First perform local energy
         minimization, to find a local potential energy minimum near the
         starting structure.''')
@@ -373,6 +374,10 @@ class Simulation(AppConfigurable):
         save the state to disk in the DCD format.''')
     statedata_freq = CInt(1000, config=True, help='''Frequency, in steps,
         to print summary statistics on the state of the simulation.''')
+    #chk_file = CBytes('traj.chk', config=True, help='''Path to a checkpoint file
+    #    to save to''')
+    #chk_freq = CInt(1000, config=True, help='''Frequency, in steps, to save checkpoint
+    #    file.''')
 
     def validate(self):
         self.log.debug('Running simulation options validations.')
@@ -516,6 +521,10 @@ class OpenMM(OpenMMApplication):
             % (self.simulation.statedata_freq, self.simulation.n_steps))
         simulation.reporters.append(ProgressReporter(sys.stdout,
             self.simulation.statedata_freq, self.simulation.n_steps))
+        #self.script('simulation.reporters.append(CheckpointReporter(%s, %s))'
+        #    % (self.simulation.chk_file, self.simulation.chk_freq))
+        #simulation.reporters.append(CheckpointReporter(self.simulation.chk_file,
+        #    self.simulation.chk_freq))
 
         self.script('simulation.step(%s)' % self.simulation.n_steps)
         if self.show_script:


### PR DESCRIPTION
Currently, its also saving the serialized system/integrator,, but I'm not sure if I like that. From the perspective of the python app, those actually AREN'T enough to reinitialize the whole simulation, because it doesn't give enough data to attach the reporters -- you still need the topology, and stuff like the report intervals. So it doesn't really make sense to claim that the checkpoint file provides the complete "machine image" of the simulation.

Also, I'm not sure I like the idea of saving the checkpoint file, v.s. the serialized state with positions and velocities only (assuming that we can solve the 1/2 timestep issue for leapfrog integrators). The positions/velocities might be more useful, even if it does lead to the random number generators being reset.
